### PR TITLE
Linux kernel 5.10 support for the sd8887 driver

### DIFF
--- a/software/drivers/sd8887/src/bluetooth/bt/bt_drv.h
+++ b/software/drivers/sd8887/src/bluetooth/bt/bt_drv.h
@@ -565,8 +565,13 @@ struct proc_private_data {
 	struct item_data *pdata;
 	/** Private structure */
 	struct _bt_private *pbt;
+
 	/** File operations */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+	const struct proc_ops *fops;
+#else
 	const struct file_operations *fops;
+#endif
 };
 
 /** Device proc structure */

--- a/software/drivers/sd8887/src/bluetooth/bt/bt_main.c
+++ b/software/drivers/sd8887/src/bluetooth/bt/bt_main.c
@@ -362,7 +362,7 @@ bt_store_firmware_dump(bt_private *priv, u8 *buf, u32 len)
 	struct file *pfile_fwdump = NULL;
 	loff_t pos = 0;
 	u16 seqnum = 0;
-	struct timeval t;
+	bt_timeval t;
 	u32 sec;
 
 	ENTER();
@@ -388,7 +388,7 @@ bt_store_firmware_dump(bt_private *priv, u8 *buf, u32 len)
 			memset(priv->adapter->fwdump_fname, 0, 64);
 
 		get_monotonic_time(&t);
-		sec = (u32)t.tv_sec;
+		sec = (u32)t.time_sec;
 		sprintf(priv->adapter->fwdump_fname, "%s%u",
 			"/var/log/bt_fwdump_", sec);
 		pfile_fwdump =

--- a/software/drivers/sd8887/src/bluetooth/bt/bt_proc.c
+++ b/software/drivers/sd8887/src/bluetooth/bt/bt_proc.c
@@ -481,19 +481,36 @@ proc_open(struct inode *inode, struct file *file)
 }
 
 /** Proc read ops */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops proc_read_ops = {
+	.proc_read = proc_read,
+	.proc_open = proc_open,
+	.proc_release = proc_close
+};
+#else
 static const struct file_operations proc_read_ops = {
 	.read = proc_read,
 	.open = proc_open,
 	.release = proc_close
 };
+#endif
 
 /** Proc Read-Write ops */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops proc_rw_ops = {
+	.proc_read = proc_read,
+	.proc_write = proc_write,
+	.proc_open = proc_open,
+	.proc_release = proc_close
+};
+#else
 static const struct file_operations proc_rw_ops = {
 	.read = proc_read,
 	.write = proc_write,
 	.open = proc_open,
 	.release = proc_close
 };
+#endif
 
 static struct proc_private_data proc_files[] = {
 	{"status", S_IRUGO, 1024,
@@ -631,6 +648,14 @@ bt_histogram_proc_open(struct inode *inode, struct file *file)
 }
 
 /** Histogram proc fops */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops histogram_proc_fops = {
+	.proc_open = bt_histogram_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+};
+#else
 static const struct file_operations histogram_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = bt_histogram_proc_open,
@@ -638,6 +663,7 @@ static const struct file_operations histogram_proc_fops = {
 	.llseek = seq_lseek,
 	.release = single_release,
 };
+#endif
 
 /**
  *  @brief This function initializes proc entry

--- a/software/drivers/sd8887/src/bluetooth/bt/bt_sdiommc.c
+++ b/software/drivers/sd8887/src/bluetooth/bt/bt_sdiommc.c
@@ -699,7 +699,7 @@ sd_request_fw_dpc(const struct firmware *fw_firmware, void *context)
 	bt_private *priv = (bt_private *)context;
 	struct sdio_mmc_card *card = NULL;
 	struct m_dev *m_dev_bt = NULL;
-	struct timeval tstamp;
+	bt_timeval tstamp;
 	int index;
 
 	ENTER();
@@ -717,8 +717,8 @@ sd_request_fw_dpc(const struct firmware *fw_firmware, void *context)
 
 	if (!fw_firmware) {
 		get_monotonic_time(&tstamp);
-		if (tstamp.tv_sec >
-		    (priv->req_fw_time.tv_sec + REQUEST_FW_TIMEOUT)) {
+		if (tstamp.time_sec >
+		    (priv->req_fw_time.time_sec + REQUEST_FW_TIMEOUT)) {
 			PRINTM(ERROR,
 			       "BT: No firmware image found. Skipping download\n");
 			ret = BT_STATUS_FAILURE;

--- a/software/drivers/sd8887/src/wlan/mlinux/mlan_decl.h
+++ b/software/drivers/sd8887/src/wlan/mlinux/mlan_decl.h
@@ -918,6 +918,14 @@ typedef MLAN_PACK_START struct _tlvbuf_custom_ie {
 	tlvbuf_max_mgmt_ie max_mgmt_ie;
 } MLAN_PACK_END mlan_ds_misc_custom_ie;
 
+/** timeval */
+typedef struct {
+	/** Time (seconds) */
+	t_u32 time_sec;
+	/** Time (micro seconds) */
+	t_u32 time_usec;
+} wifi_timeval;
+
 /** Max TDLS config data length */
 #define MAX_TDLS_DATA_LEN  1024
 

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_cfg80211.h
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_cfg80211.h
@@ -201,12 +201,17 @@ int woal_cfg80211_set_rekey_data(struct wiphy *wiphy, struct net_device *dev,
 
 void woal_mgmt_frame_register(moal_private *priv, u16 frame_type, bool reg);
 void woal_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
-#if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
+#if KERNEL_VERSION(3, 6, 0) <= CFG80211_VERSION_CODE
 				       struct wireless_dev *wdev,
 #else
 				       struct net_device *dev,
 #endif
-				       t_u16 frame_type, bool reg);
+#if KERNEL_VERSION(5, 8, 0) <= CFG80211_VERSION_CODE
+				       struct mgmt_frame_regs *upd
+#else
+				       t_u16 frame_type, bool reg
+#endif
+);
 
 int woal_cfg80211_mgmt_tx(struct wiphy *wiphy,
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_debug.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_debug.c
@@ -1105,6 +1105,15 @@ woal_debug_proc_open(struct inode *inode, struct file *file)
 #endif
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops debug_proc_fops = {
+	.proc_open = woal_debug_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+	.proc_write = woal_debug_write,
+};
+#else
 static const struct file_operations debug_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = woal_debug_proc_open,
@@ -1113,7 +1122,17 @@ static const struct file_operations debug_proc_fops = {
 	.release = single_release,
 	.write = woal_debug_write,
 };
+#endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops histogram_proc_fops = {
+	.proc_open = woal_histogram_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+	.proc_write = woal_histogram_write,
+};
+#else
 static const struct file_operations histogram_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = woal_histogram_proc_open,
@@ -1122,7 +1141,16 @@ static const struct file_operations histogram_proc_fops = {
 	.release = single_release,
 	.write = woal_histogram_write,
 };
+#endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops log_proc_fops = {
+	.proc_open = woal_log_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+};
+#else
 static const struct file_operations log_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = woal_log_proc_open,
@@ -1130,6 +1158,7 @@ static const struct file_operations log_proc_fops = {
 	.llseek = seq_lseek,
 	.release = single_release,
 };
+#endif
 
 /********************************************************
 		Global Functions

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_ioctl.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_ioctl.c
@@ -5092,7 +5092,7 @@ woal_find_essid(moal_private *priv, mlan_ssid_bssid *ssid_bssid,
 {
 	int ret = 0;
 	mlan_scan_resp scan_resp;
-	struct timeval t;
+	wifi_timeval t;
 	ENTER();
 
 	if (MLAN_STATUS_SUCCESS !=
@@ -5111,7 +5111,7 @@ woal_find_essid(moal_private *priv, mlan_ssid_bssid *ssid_bssid,
 	woal_get_monotonic_time(&t);
 /** scan result timeout value */
 #define SCAN_RESULT_AGEOUT      10
-	if (t.tv_sec > (scan_resp.age_in_secs + SCAN_RESULT_AGEOUT)) {
+	if (t.time_sec > (scan_resp.age_in_secs + SCAN_RESULT_AGEOUT)) {
 		LEAVE();
 		return MLAN_STATUS_FAILURE;
 	}

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_main.h
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_main.h
@@ -1401,7 +1401,7 @@ struct _moal_handle {
 	/** Firmware */
 	const struct firmware *firmware;
 	/** Firmware request start time */
-	struct timeval req_fw_time;
+	wifi_timeval req_fw_time;
 	/** Init config file */
 	const struct firmware *init_cfg_data;
 	/** Init config file */
@@ -2006,15 +2006,22 @@ woal_get_priv_bss_type(moal_handle *handle, mlan_bss_type bss_type)
 	return NULL;
 }
 
-static inline void
-woal_get_monotonic_time(struct timeval *tv)
+static inline void woal_get_monotonic_time(wifi_timeval *tv)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+	struct timespec64 ts;
+#else
 	struct timespec ts;
+#endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+	ktime_get_raw_ts64(&ts);
+#else
 	getrawmonotonic(&ts);
+#endif
 	if (tv) {
-		tv->tv_sec = ts.tv_sec;
-		tv->tv_usec = ts.tv_nsec / 1000;
+		tv->time_sec = (t_u32)ts.tv_sec;
+		tv->time_usec = (t_u32)ts.tv_nsec / 1000;
 	}
 }
 

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_proc.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_proc.c
@@ -276,6 +276,14 @@ woal_info_proc_open(struct inode *inode, struct file *file)
 #endif
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops info_proc_fops = {
+	.proc_open = woal_info_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+};
+#else
 static const struct file_operations info_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = woal_info_proc_open,
@@ -283,6 +291,7 @@ static const struct file_operations info_proc_fops = {
 	.llseek = seq_lseek,
 	.release = single_release,
 };
+#endif
 
 #define     CMD52_STR_LEN   50
 /*
@@ -488,6 +497,15 @@ woal_config_proc_open(struct inode *inode, struct file *file)
 #endif
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+static const struct proc_ops config_proc_fops = {
+	.proc_open = woal_config_proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
+	.proc_write = woal_config_write,
+};
+#else
 static const struct file_operations config_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = woal_config_proc_open,
@@ -496,6 +514,7 @@ static const struct file_operations config_proc_fops = {
 	.release = single_release,
 	.write = woal_config_write,
 };
+#endif
 
 /********************************************************
 		Global Functions

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_shim.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_shim.c
@@ -287,11 +287,11 @@ moal_udelay(IN t_void *pmoal_handle, IN t_u32 delay)
 mlan_status
 moal_get_system_time(IN t_void *pmoal_handle, OUT t_u32 *psec, OUT t_u32 *pusec)
 {
-	struct timeval t;
+	wifi_timeval t;
 
 	woal_get_monotonic_time(&t);
-	*psec = (t_u32)t.tv_sec;
-	*pusec = (t_u32)t.tv_usec;
+	*psec = t.time_sec;
+	*pusec = t.time_usec;
 
 	return MLAN_STATUS_SUCCESS;
 }

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_sta_cfg80211.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_sta_cfg80211.c
@@ -372,9 +372,12 @@ static struct cfg80211_ops woal_cfg80211_ops = {
 		woal_cfg80211_channel_switch,
 #endif
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)
-		.mgmt_frame_register =
-		woal_cfg80211_mgmt_frame_register,.mgmt_tx =
-		woal_cfg80211_mgmt_tx,
+#if CFG80211_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+	.update_mgmt_frame_registrations = woal_cfg80211_mgmt_frame_register,
+#else
+	.mgmt_frame_register = woal_cfg80211_mgmt_frame_register,
+#endif
+	.mgmt_tx = woal_cfg80211_mgmt_tx,
 #endif
 #endif
 #if CFG80211_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)

--- a/software/drivers/sd8887/src/wlan/mlinux/moal_sta_cfg80211.c
+++ b/software/drivers/sd8887/src/wlan/mlinux/moal_sta_cfg80211.c
@@ -3614,7 +3614,7 @@ t_u8
 woal_is_scan_result_expired(moal_private *priv)
 {
 	mlan_scan_resp scan_resp;
-	struct timeval t;
+	wifi_timeval t;
 	ENTER();
 	if (!woal_is_any_interface_active(priv->phandle)) {
 		LEAVE();
@@ -3629,7 +3629,7 @@ woal_is_scan_result_expired(moal_private *priv)
 	woal_get_monotonic_time(&t);
 /** scan result expired value */
 #define SCAN_RESULT_EXPIRTED      1
-	if (t.tv_sec > (scan_resp.age_in_secs + SCAN_RESULT_EXPIRTED)) {
+	if (t.time_sec > (scan_resp.age_in_secs + SCAN_RESULT_EXPIRTED)) {
 		LEAVE();
 		return MTRUE;
 	}


### PR DESCRIPTION
Various changes necessary for the sd8887 driver to compile and run on Linux kernel up to version 5.10. Tested on both latest Raspbian with kernel 5.10 and balenaOS current.